### PR TITLE
Update setup.cfg

### DIFF
--- a/markserial_pkg/setup.cfg
+++ b/markserial_pkg/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/markserial_pkg
+script_dir=$base/lib/markserial_pkg
 [install]
-install-scripts=$base/lib/markserial_pkg
+install_scripts=$base/lib/markserial_pkg


### PR DESCRIPTION
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
--- stderr: markserial_pkg
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(