### PR TITLE
add 'find_package'

### DIFF
--- a/markserial_interfaces/CMakeLists.txt
+++ b/markserial_interfaces/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ament_cmake REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
colcon gives error wthout find_package(rosidl_default_generators REQUIRED)